### PR TITLE
many2many, joinForeignKey, JoinReferences support

### DIFF
--- a/deep-filtering.go
+++ b/deep-filtering.go
@@ -203,17 +203,18 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 		fieldStructInstance: sourceStructType,
 	}
 
-	sourceForeignKey, ok := dbField.TagSettings["FOREIGNKEY"]
-	if ok {
-		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, sourceForeignKey)
-		return result, nil
+	// Detetct many2many and foreignkey at the same time (fields can have both defined)
+	sourceForeignKey, sourceForeignKeyOk := dbField.TagSettings["FOREIGNKEY"]
+	manyToMany, manyToManyOk := dbField.TagSettings["MANY2MANY"]
+
+	if !sourceForeignKeyOk && !manyToManyOk {
+		return nil, fmt.Errorf("no 'foreignKey:...' or 'many2many:...' found in field %s", dbField.Name)
 	}
 
-	// No foreign key found, then it must be a manyToMany
-	manyToMany, ok := dbField.TagSettings["MANY2MANY"]
-
-	if !ok {
-		return nil, fmt.Errorf("no 'foreignKey:...' or 'many2many:...' found in field %s", dbField.Name)
+	// Only foreignkey
+	if sourceForeignKeyOk && !manyToManyOk {
+		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, sourceForeignKey)
+		return result, nil
 	}
 
 	// Woah it's a many-to-many!
@@ -221,10 +222,20 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 	result.manyToManyTable = manyToMany
 
 	// Based on the type we can just put _id behind it, again this only works with simple many-to-many structs
-	result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, ensureNotASlice(dbField.FieldType).Name()) + "_id"
+	fieldForeignKey, ok := dbField.TagSettings["JOINREFERENCES"]
+	if ok {
+		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, fieldForeignKey)
+	} else {
+		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, ensureNotASlice(dbField.FieldType).Name()) + "_id"
+	}
 
 	// Now the other table that we're getting information from.
-	result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, ofType.Name()) + "_id"
+	destinationManyToManyForeignKey, ok := dbField.TagSettings["JOINFOREIGNKEY"]
+	if ok {
+		result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, destinationManyToManyForeignKey)
+	} else {
+		result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, ofType.Name()) + "_id"
+	}
 
 	return result, nil
 }

--- a/deep-filtering.go
+++ b/deep-filtering.go
@@ -126,6 +126,10 @@ func AddDeepFilters(db *gorm.DB, objectType any, filters ...map[string]any) (*go
 type nestedType struct {
 	// An empty instance of the object, used in db.Model(...)
 	fieldStructInstance any
+	// The primary key column of fieldStructInstance.
+	fieldPrimaryKey string
+	// The primary key column of the current model being filtered.
+	currentPrimaryKey string
 	fieldForeignKey     string
 
 	// Whether this is a manyToOne, oneToMany or manyToMany. oneToOne is taken care of automatically.
@@ -203,6 +207,16 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 		fieldStructInstance: sourceStructType,
 	}
 
+	if len(dbField.Schema.PrimaryFields) > 0 {
+		result.currentPrimaryKey = dbField.Schema.PrimaryFields[0].DBName
+	}
+
+	if relatedSchema, err := schema.Parse(sourceStructType, &schemaCache, naming); err == nil && len(relatedSchema.PrimaryFields) > 0 {
+		result.fieldPrimaryKey = relatedSchema.PrimaryFields[0].DBName
+	}
+
+	relation := dbField.Schema.Relationships.Relations[dbField.Name]
+
 	// Detetct many2many and foreignkey at the same time (fields can have both defined)
 	sourceForeignKey, sourceForeignKeyOk := dbField.TagSettings["FOREIGNKEY"]
 	manyToMany, manyToManyOk := dbField.TagSettings["MANY2MANY"]
@@ -213,7 +227,16 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 
 	// Only foreignkey
 	if sourceForeignKeyOk && !manyToManyOk {
-		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, sourceForeignKey)
+		if sourceField := dbField.Schema.LookUpField(sourceForeignKey); sourceField != nil {
+			result.fieldForeignKey = sourceField.DBName
+		} else {
+			result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, sourceForeignKey)
+		}
+
+		if relation != nil && len(relation.References) > 0 {
+			result.fieldPrimaryKey = relation.References[0].PrimaryKey.DBName
+		}
+
 		return result, nil
 	}
 
@@ -221,20 +244,45 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 	result.relationType = "manyToMany"
 	result.manyToManyTable = manyToMany
 
+	if relation != nil {
+		for _, ref := range relation.References {
+			if ref.OwnPrimaryKey {
+				result.destinationManyToManyForeignKey = ref.ForeignKey.DBName
+				result.currentPrimaryKey = ref.PrimaryKey.DBName
+				continue
+			}
+
+			result.fieldForeignKey = ref.ForeignKey.DBName
+			result.fieldPrimaryKey = ref.PrimaryKey.DBName
+		}
+	}
+
 	// Based on the type we can just put _id behind it, again this only works with simple many-to-many structs
-	fieldForeignKey, ok := dbField.TagSettings["JOINREFERENCES"]
-	if ok {
-		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, fieldForeignKey)
-	} else {
-		result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, ensureNotASlice(dbField.FieldType).Name()) + "_id"
+	if result.fieldForeignKey == "" {
+		fieldForeignKey, ok := dbField.TagSettings["JOINREFERENCES"]
+		if ok {
+			if sourceField := dbField.Schema.LookUpField(fieldForeignKey); sourceField != nil {
+				result.fieldForeignKey = sourceField.DBName
+			} else {
+				result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, fieldForeignKey)
+			}
+		} else {
+			result.fieldForeignKey = naming.ColumnName(dbField.Schema.Table, ensureNotASlice(dbField.FieldType).Name()) + "_id"
+		}
 	}
 
 	// Now the other table that we're getting information from.
-	destinationManyToManyForeignKey, ok := dbField.TagSettings["JOINFOREIGNKEY"]
-	if ok {
-		result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, destinationManyToManyForeignKey)
-	} else {
-		result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, ofType.Name()) + "_id"
+	if result.destinationManyToManyForeignKey == "" {
+		destinationManyToManyForeignKey, ok := dbField.TagSettings["JOINFOREIGNKEY"]
+		if ok {
+			if destinationField := dbField.Schema.LookUpField(destinationManyToManyForeignKey); destinationField != nil {
+				result.destinationManyToManyForeignKey = destinationField.DBName
+			} else {
+				result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, destinationManyToManyForeignKey)
+			}
+		} else if ofType != nil {
+			result.destinationManyToManyForeignKey = naming.ColumnName(dbField.Schema.Table, ofType.Name()) + "_id"
+		}
 	}
 
 	return result, nil
@@ -267,7 +315,7 @@ func getNestedType(naming schema.Namer, dbField *schema.Field, ofType reflect.Ty
 func getDatabaseFieldsOfType(naming schema.Namer, schemaInfo *schema.Schema) map[string]*nestedType {
 	// First get all the information of the to-be-reflected object
 	reflectType := ensureConcrete(schemaInfo.ModelType)
-	reflectTypeName := reflectType.Name()
+	reflectTypeName := reflectType.String()
 
 	// The len(dbFields) check is needed here because when running the unit tests
 	// it fell into a race condition where it had the map key already stored but not the value yet.
@@ -313,7 +361,7 @@ func addDeepFilter(db *gorm.DB, fieldInfo *nestedType, filter any) (*gorm.DB, er
 			return nil, err
 		}
 
-		return db.Where(whereQuery, cleanDB.Model(fieldInfo.fieldStructInstance).Select("id").Where(subQuery)), nil
+		return db.Where(whereQuery, cleanDB.Model(fieldInfo.fieldStructInstance).Select(fieldInfo.fieldPrimaryKey).Where(subQuery)), nil
 
 	case "manyToOne":
 		// SELECT * FROM <table> WHERE id IN (SELECT fieldInfo.fieldStructInstance FROM fieldInfo.fieldStructInstance WHERE filter)
@@ -323,7 +371,7 @@ func addDeepFilter(db *gorm.DB, fieldInfo *nestedType, filter any) (*gorm.DB, er
 			return nil, err
 		}
 
-		return db.Where("id IN (?)", cleanDB.Model(fieldInfo.fieldStructInstance).Select(fieldInfo.fieldForeignKey).Where(subQuery)), nil
+		return db.Where(fmt.Sprintf("%s IN (?)", fieldInfo.currentPrimaryKey), cleanDB.Model(fieldInfo.fieldStructInstance).Select(fieldInfo.fieldForeignKey).Where(subQuery)), nil
 
 	case "manyToMany":
 		// SELECT * FROM <table> WHERE id IN (SELECT <table>_id FROM fieldInfo.fieldForeignKey WHERE <other_table>_id IN (SELECT id FROM <other_table> WHERE givenFilter))
@@ -336,7 +384,7 @@ func addDeepFilter(db *gorm.DB, fieldInfo *nestedType, filter any) (*gorm.DB, er
 			return nil, err
 		}
 
-		return db.Where("id IN (?)", cleanDB.Table(fieldInfo.manyToManyTable).Select(fieldInfo.destinationManyToManyForeignKey).Where(subWhere, cleanDB.Model(fieldInfo.fieldStructInstance).Select("id").Where(subQuery))), nil
+		return db.Where(fmt.Sprintf("%s IN (?)", fieldInfo.currentPrimaryKey), cleanDB.Table(fieldInfo.manyToManyTable).Select(fieldInfo.destinationManyToManyForeignKey).Where(subWhere, cleanDB.Model(fieldInfo.fieldStructInstance).Select(fieldInfo.fieldPrimaryKey).Where(subQuery))), nil
 	}
 
 	return nil, fmt.Errorf("relationType '%s' unknown", fieldInfo.relationType)

--- a/deep-filtering_test.go
+++ b/deep-filtering_test.go
@@ -553,6 +553,8 @@ func TestGetNestedType_ReturnsExpectedTypeInfoOnManyToMany(t *testing.T) {
 	// This is what ManyA should return
 	expected := &nestedType{
 		fieldStructInstance:             &ManyB{},
+		fieldPrimaryKey:                 "id",
+		currentPrimaryKey:               "id",
 		fieldForeignKey:                 "many_b_id",
 		relationType:                    "manyToMany",
 		manyToManyTable:                 "a_b",
@@ -565,6 +567,53 @@ func TestGetNestedType_ReturnsExpectedTypeInfoOnManyToMany(t *testing.T) {
 	// Assert
 	assert.Nil(t, err)
 
+	if assert.NotNil(t, result) {
+		assert.EqualValues(t, expected, result)
+	}
+}
+
+func TestGetNestedType_ReturnsExpectedTypeInfoOnManyToManyWithCustomColumns(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(cleanupCache)
+
+	type End struct {
+		ID    uuid.UUID `gorm:"column:endId;primaryKey"`
+		Value string    `gorm:"column:endValue"`
+	}
+
+	type Middle struct {
+		ID         uuid.UUID `gorm:"column:middleId;primaryKey"`
+		ResourceID uuid.UUID `gorm:"column:resourceIdJ"`
+		EndID      uuid.UUID `gorm:"column:endIdJ"`
+	}
+
+	type Resource struct {
+		ID   uuid.UUID `gorm:"column:resourceId;primaryKey"`
+		Name string    `gorm:"column:resourceName"`
+		Ends []*End    `gorm:"foreignKey:ID;many2many:middles;joinForeignKey:ResourceID;references:ID;joinReferences:EndID"`
+	}
+
+	naming := gormtestutil.NewMemoryDatabase(t, gormtestutil.WithName(t.Name())).NamingStrategy
+
+	schemaInfo, _ := schema.Parse(Resource{}, &sync.Map{}, naming)
+	field := schemaInfo.FieldsByName["Ends"]
+
+	inputType := reflect.TypeOf(Resource{})
+
+	// This is what Resource should return
+	expected := &nestedType{
+		fieldStructInstance:             &End{},
+		fieldPrimaryKey:                 "endId",
+		currentPrimaryKey:               "resourceId",
+		fieldForeignKey:                 "end_id",
+		relationType:                    "manyToMany",
+		manyToManyTable:                 "middles",
+		destinationManyToManyForeignKey: "resource_id",
+	}
+
+	result, err := getNestedType(naming, field, inputType)
+
+	assert.Nil(t, err)
 	if assert.NotNil(t, result) {
 		assert.EqualValues(t, expected, result)
 	}
@@ -2868,6 +2917,100 @@ func TestAddDeepFilters_AddsDeepFiltersWithManyToMany2OnMultiFilter(t *testing.T
 				assert.Nil(t, res.Error)
 
 				assert.EqualValues(t, testData.expected, result)
+			}
+		})
+	}
+}
+
+func TestAddDeepFilters_AddsDeepFiltersWithManyToManyCustomColumns(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(cleanupCache)
+
+	type End struct {
+		ID    uuid.UUID `gorm:"column:endId;primaryKey"`
+		Value string    `gorm:"column:endValue"`
+	}
+
+	type Resource struct {
+		ID   uuid.UUID `gorm:"column:resourceId;primaryKey"`
+		Name string    `gorm:"column:resourceName"`
+		Ends []*End    `gorm:"foreignKey:ID;many2many:resource_ends;references:ID"`
+	}
+
+	tests := map[string]struct {
+		records   []*Resource
+		expected  []Resource
+		filterMap map[string]any
+	}{
+		"looking for 1 resource": {
+			records: []*Resource{
+				{
+					ID:   uuid.MustParse("59aa5a8f-c5de-44fa-9355-080650481687"),
+					Name: "TestResource",
+					Ends: []*End{
+						{
+							ID:    uuid.MustParse("c53184d8-e506-49f4-af18-93fb370f6df2"),
+							Value: "InfraNL",
+						},
+						{
+							ID:    uuid.MustParse("4de16d5f-c10f-4206-b6ce-c14997341113"),
+							Value: "Blub",
+						},
+					},
+				},
+			},
+			expected: []Resource{
+				{
+					ID:   uuid.MustParse("59aa5a8f-c5de-44fa-9355-080650481687"),
+					Name: "TestResource",
+					Ends: []*End{
+						{
+							ID:    uuid.MustParse("c53184d8-e506-49f4-af18-93fb370f6df2"),
+							Value: "InfraNL",
+						},
+						{
+							ID:    uuid.MustParse("4de16d5f-c10f-4206-b6ce-c14997341113"),
+							Value: "Blub",
+						},
+					},
+				},
+			},
+			filterMap: map[string]any{
+				"ends": map[string]any{
+					"endValue": "InfraNL",
+				},
+			},
+		},
+	}
+
+	for name, testData := range tests {
+		testData := testData
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Arrange
+			database := gormtestutil.NewMemoryDatabase(t, gormtestutil.WithName(t.Name()))
+			_ = database.AutoMigrate(&Resource{}, &End{})
+
+			database.CreateInBatches(testData.records, len(testData.records))
+
+			// Act
+			query, err := AddDeepFilters(database, Resource{}, testData.filterMap)
+
+			// Assert
+			assert.Nil(t, err)
+
+			if assert.NotNil(t, query) {
+				var result []Resource
+				res := query.Preload(clause.Associations).Find(&result)
+
+				// Handle error
+				assert.Nil(t, res.Error)
+
+				if assert.Len(t, result, 1) {
+					assert.Equal(t, testData.expected[0].ID, result[0].ID)
+					assert.Equal(t, testData.expected[0].Name, result[0].Name)
+					assert.ElementsMatch(t, testData.expected[0].Ends, result[0].Ends)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Before this change, a field that defined both many2many and foreignKey would always be detected as foreignKey incorrectly.
This will now be detected correctly.

In cases of a many2many reference joinForeignKey
and JoinReferences will now also be used to get the field names rather than inventing them.

I have actually been running this version in my mysql app since aronud August 2023 (3 years)
And have just updated gorm, meaning I have to apply this on the latest version of this package
And it still seems to work well!